### PR TITLE
Moving the  competition, sign in and login content under the banner f…

### DIFF
--- a/the-brink/src/Competition.css
+++ b/the-brink/src/Competition.css
@@ -8,7 +8,7 @@ body{
     max-width: 2000px;
     margin: 0 auto;
     padding: 20px;
-    padding-top: 200px;
+    padding-top: 400px;
     text-align: center;
     font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
    

--- a/the-brink/src/Loginpage.css
+++ b/the-brink/src/Loginpage.css
@@ -32,7 +32,7 @@ body{
     max-width: 1200px;
     width: 100%;
     height: 800px;
-    margin-top: 800px;
+    margin-top: 1200px;
 }
 
 .login-box h2{

--- a/the-brink/src/SignUpPage.css
+++ b/the-brink/src/SignUpPage.css
@@ -32,7 +32,7 @@ body{
     max-width: 1200px;
     width: 100%;
     height: 800px;
-    margin-top: 800px;
+    margin-top: 1200px;
 }
 
 .sign-up-box h2{


### PR DESCRIPTION
…or full screen view