### PR TITLE
Expose frontend container to host

### DIFF
--- a/the-brink/docker-compose.yml
+++ b/the-brink/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       NODE_OPTIONS: "--openssl-legacy-provider"
       HOST: "0.0.0.0"
       DANGEROUSLY_DISABLE_HOST_CHECK: "true"
+    ports:
+      - "3000:3000"
 
   backend:
     container_name: api


### PR DESCRIPTION

# Overview

**Type of Change:** Bug Fix

**Summary:** Exposed the frontend container to the host machine by modifying the `docker-compose.yml` file. This change resolves the issue where the frontend React application was not accessible via `localhost` due to missing port mappings.

## UI/UX Implementation

No changes made.

## Model Updates

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

1. Run `docker compose up -d --build` to rebuild and restart all containers.
2. Visit `http://localhost:3000` in your browser.
3. Confirm that the frontend React application is now loading correctly.
4. Navigate through the application to confirm it functions as expected.